### PR TITLE
Add optional argument that will fix nullable database-values causing no results

### DIFF
--- a/src/Doctrine/Orm/Filter/ExpressionFilter.php
+++ b/src/Doctrine/Orm/Filter/ExpressionFilter.php
@@ -24,6 +24,7 @@ final class ExpressionFilter extends AbstractContextAwareFilter
      * @param array<string, string>|null $properties
      * @param ContextAwareFilterInterface[] $filters
      * @param NameConverterInterface|null $nameConverter
+     * @param bool $innerJoinsLeft
      */
     public function __construct(
         ManagerRegistry $managerRegistry,
@@ -32,12 +33,13 @@ final class ExpressionFilter extends AbstractContextAwareFilter
         LoggerInterface $logger = null,
         array $properties = null,
         array $filters = null,
-        NameConverterInterface $nameConverter = null
+        NameConverterInterface $nameConverter = null,
+        bool $innerJoinsLeft = false
     ) {
         parent::__construct($managerRegistry, $requestStack, $logger, $properties, $nameConverter);
 
         $this->expressionLanguage = $expressionLanguage;
-        $this->expressionLanguage->registerProvider(new FilterExpressionProvider($filters));
+        $this->expressionLanguage->registerProvider(new FilterExpressionProvider($filters, $innerJoinsLeft));
     }
 
     /**


### PR DESCRIPTION
If the 'innerJoinsLeft' filter argument is set to true,  INNER joins will be replaced with LEFT joins. This prevents any null values to "break" the filter and return no results. See more here: https://github.com/metaclass-nl/filter-bundle#nested-properties-workaround

Thanks [to code](https://github.com/metaclass-nl/filter-bundle/blob/b7d66864645fd651a4c8c6942bf18087af9b6f29/src/Filter/FilterLogic.php#L284) from metaclass-nl

If code is acceptable I'll update the README as well.